### PR TITLE
Replace fmt.Sscanf with strconv.Atoi for faster int conversion

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -3,6 +3,7 @@ package fgprof
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -15,7 +16,7 @@ func Handler() http.Handler {
 		var seconds int
 		if s := r.URL.Query().Get("seconds"); s == "" {
 			seconds = 30
-		} else if _, err := fmt.Sscanf(s, "%d", &seconds); err != nil || seconds <= 0 {
+		} else if seconds, err := strconv.Atoi(s); err != nil || seconds <= 0 {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "bad seconds: %d: %s\n", seconds, err)
 		}

--- a/handler.go
+++ b/handler.go
@@ -14,9 +14,10 @@ import (
 func Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var seconds int
+		var err error
 		if s := r.URL.Query().Get("seconds"); s == "" {
 			seconds = 30
-		} else if seconds, err := strconv.Atoi(s); err != nil || seconds <= 0 {
+		} else if seconds, err = strconv.Atoi(s); err != nil || seconds <= 0 {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "bad seconds: %d: %s\n", seconds, err)
 		}

--- a/handler.go
+++ b/handler.go
@@ -20,6 +20,7 @@ func Handler() http.Handler {
 		} else if seconds, err = strconv.Atoi(s); err != nil || seconds <= 0 {
 			w.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(w, "bad seconds: %d: %s\n", seconds, err)
+			return
 		}
 
 		format := Format(r.URL.Query().Get("format"))


### PR DESCRIPTION
Ran a benchmark with this change and saw significant decrease(98.6%) in the runtime.
Also added early return in `else if` block to fail early.

Test code:

```
func BenchmarkFmtSscanf(b *testing.B) {
	var seconds int
	for i := 0; i < b.N; i++ {
		_, _ = fmt.Sscanf("300", "%d", &seconds)
		_ = seconds

	}
}

func BenchmarkAtoi(b *testing.B) {
	for i := 0; i < b.N; i++ {
		seconds, _ := strconv.Atoi("-300")
		_ = seconds
	}
}
```

Test Results:
```
➜  go-code git:(master) ✗ go test -bench=. a_test.go
goos: darwin
goarch: amd64
BenchmarkFmtSscanf-8           2430686               486 ns/op
BenchmarkAtoi-8                    176275149                6.66 ns/op
```