### PR TITLE
Reduce allocations while creating a slice of keys from map and fix a …

### DIFF
--- a/fgprof.go
+++ b/fgprof.go
@@ -69,7 +69,7 @@ func (p *profiler) GoroutineProfile() []runtime.StackRecord {
 	// We don't know how many goroutines exist, so we have to grow p.stacks
 	// dynamically. We overshoot by 10% since it's possible that more goroutines
 	// are launched in between two calls to GoroutineProfile. Once p.stacks
-	// reaches the maximum numnber of goroutines used by the program, it will get
+	// reaches the maximum number of goroutines used by the program, it will get
 	// reused indefinitely, eliminating GoroutineProfile calls and allocations.
 	//
 	// TODO(fg) There might be workloads where it would be nice to shrink

--- a/format.go
+++ b/format.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/pprof/profile"
 )
 
+// Format decides how the ouput is rendered to the user.
 type Format string
 
 const (
@@ -93,9 +94,11 @@ func toPprof(s map[string]int, hz int) *profile.Profile {
 }
 
 func sortedKeys(s map[string]int) []string {
-	var keys []string
+	keys := make([]string, len(s))
+	i := 0
 	for stack := range s {
-		keys = append(keys, stack)
+		keys[i] = stack
+		i++
 	}
 	sort.Strings(keys)
 	return keys


### PR DESCRIPTION
…typo

- This PR reduces the no. of allocations by ~83% and increases the speed by ~48% which creating the slice while forming the key slice from a map. 
- Also fixed a small typo and added one doc string.

Benchmark script:  https://play.golang.org/p/1Qv2z4W0EMO

Results:
```
➜  dev-vm go test -v -run=^$ -bench=BenchmarkMapSlice a_test.go --count=20 >> {old,new}.txt
➜  dev-vm benchstat old.txt new.txt                                                                  
name        old time/op    new time/op    delta
MapSlice-8    1.29µs ± 4%    0.68µs ± 6%  -47.57%  (p=0.000 n=20+20)

name        old alloc/op   new alloc/op   delta
MapSlice-8    1.01kB ± 0%    0.51kB ± 0%  -49.21%  (p=0.000 n=20+20)

name        old allocs/op  new allocs/op  delta
MapSlice-8      6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=20+20)
```