### PR TITLE
Preallocate p.stacks() before calling runtime.GoroutineProfile()

### DIFF
--- a/fgprof.go
+++ b/fgprof.go
@@ -58,7 +58,6 @@ func newProfiler() *profiler {
 	return &profiler{
 		stacks: make([]runtime.StackRecord, int(float64(n)*1.1)),
 	}
-	//return &profiler{}
 }
 
 // GoroutineProfile returns the stacks of all goroutines currently managed by
@@ -89,7 +88,6 @@ func (p *profiler) GoroutineProfile() []runtime.StackRecord {
 	for {
 		n, ok := runtime.GoroutineProfile(p.stacks)
 		if !ok {
-			//fmt.Printf("realloc\n")
 			p.stacks = make([]runtime.StackRecord, int(float64(n)*1.1))
 		} else {
 			return p.stacks[0:n]

--- a/fgprof.go
+++ b/fgprof.go
@@ -75,6 +75,11 @@ func (p *profiler) GoroutineProfile() []runtime.StackRecord {
 	// TODO(fg) There might be workloads where it would be nice to shrink
 	// p.stacks dynamically as well, but let's not over-engineer this until we
 	// understand those cases better.
+
+	nGoroutines := runtime.NumGoroutine()
+	if len(p.stacks) < nGoroutines {
+		p.stacks = make([]runtime.StackRecord, int(float64(nGoroutines)*1.1))
+	}
 	for {
 		n, ok := runtime.GoroutineProfile(p.stacks)
 		if !ok {

--- a/fgprof_test.go
+++ b/fgprof_test.go
@@ -34,7 +34,7 @@ func BenchmarkProfiler(b *testing.B) {
 }
 
 func BenchmarkProfilerGoroutines(b *testing.B) {
-	for g := 10000; g <= 10000; g = g * 2 {
+	for g := 1; g <= 1024*1024; g = g * 2 {
 		g := g
 		name := fmt.Sprintf("%d goroutines", g)
 

--- a/fgprof_test.go
+++ b/fgprof_test.go
@@ -3,6 +3,7 @@ package fgprof
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -26,20 +27,19 @@ func TestStart(t *testing.T) {
 }
 
 func BenchmarkProfiler(b *testing.B) {
-	prof := &profiler{}
+	prof := newProfiler()
 	for i := 0; i < b.N; i++ {
 		prof.GoroutineProfile()
 	}
 }
 
 func BenchmarkProfilerGoroutines(b *testing.B) {
-	for g := 1; g <= 1024*1024; g = g * 2 {
+	for g := 10000; g <= 10000; g = g * 2 {
 		g := g
 		name := fmt.Sprintf("%d goroutines", g)
 
 		b.Run(name, func(b *testing.B) {
-			prof := &profiler{}
-			initalRoutines := len(prof.GoroutineProfile())
+			initalRoutines := runtime.NumGoroutine()
 
 			readyCh := make(chan struct{})
 			stopCh := make(chan struct{})
@@ -50,6 +50,9 @@ func BenchmarkProfilerGoroutines(b *testing.B) {
 				}()
 				<-readyCh
 			}
+
+			// allocate profiler after some goroutines has been generated
+			prof := newProfiler()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -78,7 +81,7 @@ func BenchmarkProfilerGoroutines(b *testing.B) {
 }
 
 func BenchmarkStackCounter(b *testing.B) {
-	prof := &profiler{}
+	prof := newProfiler()
 	stacks := prof.GoroutineProfile()
 	sc := stackCounter{}
 	b.ResetTimer()


### PR DESCRIPTION
Fixes https://github.com/felixge/fgprof/issues/10