### PR TITLE
fix panic: divide by zero

### DIFF
--- a/fgprof.go
+++ b/fgprof.go
@@ -226,6 +226,10 @@ func (p *wallclockProfile) exportFolded(w io.Writer) error {
 
 func (p *wallclockProfile) exportPprof(hz int, startTime, endTime time.Time) *profile.Profile {
 	prof := &profile.Profile{}
+	if hz == 0 {
+		return prof
+	}
+
 	m := &profile.Mapping{ID: 1, HasFunctions: true}
 	prof.Period = int64(1e9 / hz) // Number of nanoseconds between samples.
 	prof.TimeNanos = startTime.UnixNano()


### PR DESCRIPTION
Hi, thx for the great tool!

# Problem

In production we use fgprof + alloy + pyroscope. Sometimes we catch panic:

```
runtime error: integer divide by zero\ngoroutine 11398149 [running]:\nnet/http.(*conn).serve.func1()\n\t/usr/local/go/src/net/http/server.go:1854 +0xbf\npanic({0x15b3320, 0x260a9b0})\n\t/usr/local/go/src/runtime/panic.go:890 +0x263\ngithub.com/felixge/fgprof.(*wallclockProfile).exportPprof(0xc013442a00, 0x0, {0xc000100000?, 0xc015015020?, 0x262e600?}, {0xc005ccd540?, 0x40e007?, 0x262e600?})\n\t/go/src/app/vendor/github.com/felixge/fgprof/fgprof.go:220
```

Same problem described [here](https://github.com/felixge/fgprof/issues/30).


Panic reproduced in tests when stop called straight after start without sleep.

# Possible solution

Check pprof sampling rate on zero before exportPprof calling.  
