### PR TITLE
Set Content-Type to application/octet-stream for pprof format

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -28,6 +28,12 @@ func Handler() http.Handler {
 			format = FormatPprof
 		}
 
+		if format == FormatPprof {
+			// Set Content Type assuming Start will work,
+			// because if it does it starts writing.
+			w.Header().Set("Content-Type", "application/octet-stream")
+		}
+
 		stop := Start(w, format)
 		defer stop()
 		time.Sleep(time.Duration(seconds) * time.Second)


### PR DESCRIPTION
Hi, thanks for creating this great tool!

## Problem

When fgprof is scraped by Grafana Alloy with profiling enabled, 
Alloy checks the Content-Type header and expects it to start with `application/octet-stream`.
Since https://github.com/grafana/alloy/pull/4190, responses with a different header are rejected with:

```
err="invalid profile data: unexpected Content-Type application/x-gzip, expected application/octet-stream for pprof data"
```

The Go standard library’s `net/http/pprof` and `pyroscope-go` both set:

```go
w.Header().Set("Content-Type", "application/octet-stream")
```

- https://cs.opensource.google/go/go/+/refs/tags/go1.26.0:src/net/http/pprof/pprof.go;l=154-156
- https://github.com/grafana/pyroscope-go/blob/18b0c5190246dc2573b6d99358e5e3b8535a2019/http/pprof/pprof.go#L34-L36

## Change

Set Content-Type to `application/octet-stream` when "format" is "pprof" (default), matching the behavior of `net/http/pprof`.