### PR TITLE
fix: handle zero sample rate in pprof export

### DIFF
--- a/fgprof.go
+++ b/fgprof.go
@@ -70,7 +70,11 @@ func Start(w io.Writer, format Format) func() error {
 		// direction and improves the correctness of times in profiles.
 		duration := endTime.Sub(startTime)
 		actualHz := float64(sampleCount) / (float64(duration) / 1e9)
-		return profile.Export(w, format, int(math.Round(actualHz)), startTime, endTime)
+		measuredHz := int(math.Round(actualHz))
+		if measuredHz < 1 {
+			measuredHz = hz
+		}
+		return profile.Export(w, format, measuredHz, startTime, endTime)
 	}
 }
 

--- a/fgprof_test.go
+++ b/fgprof_test.go
@@ -61,6 +61,17 @@ func TestStart(t *testing.T) {
 	}
 }
 
+func TestStartPprofWithoutSamples(t *testing.T) {
+	prof := &bytes.Buffer{}
+	stop := Start(prof, FormatPprof)
+	require.NoError(t, stop())
+
+	pprof, err := profile.ParseData(prof.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, pprof.CheckValid())
+	require.NotZero(t, pprof.Period)
+}
+
 func Test_toPprof(t *testing.T) {
 	foo := &runtime.Frame{PC: 1, Function: "foo", File: "foo.go", Line: 23}
 	bar := &runtime.Frame{PC: 2, Function: "bar", File: "bar.go", Line: 42}


### PR DESCRIPTION
## Summary

Fix a panic in pprof export when wall-clock profiling is stopped before the first sample is collected.

In that case, `sampleCount` is zero, so the measured sample rate rounds to `0`. Passing that value into `exportPprof` causes a divide-by-zero panic while calculating the profile
period.

This patch falls back to the configured sampling rate when the measured rate is less than `1`.

## Reproducer

A short-lived program can trigger this by starting and immediately stopping pprof-format profiling:

```go
package main

import "github.com/felixge/fgprof"

func main() {
    stop := fgprof.Start(io.Discard, fgprof.FormatPprof)
    _ = stop()
}
